### PR TITLE
Fixed settings on Pharo 7 (#1)

### DIFF
--- a/src/Mirage-Carousel/MICarousel.class.st
+++ b/src/Mirage-Carousel/MICarousel.class.st
@@ -16,7 +16,7 @@ Class {
 	#classInstVars : [
 		'isActivated'
 	],
-	#category : 'Mirage-Carousel-Morphic'
+	#category : #'Mirage-Carousel-Morphic'
 }
 
 { #category : #accessing }
@@ -26,8 +26,8 @@ MICarousel class >> activate: aBoolean [
 
 { #category : #'initialize-release' }
 MICarousel class >> initialize [
-	super initialize.
-	self activate: false
+
+	self activate: true
 ]
 
 { #category : #accessing }
@@ -37,6 +37,7 @@ MICarousel class >> isActivated [
 
 { #category : #settings }
 MICarousel class >> wpSettingOn: aBuilder [
+
 	<systemsettings>
 	(self buildSettingNamed: #wpCarouselSetting with: aBuilder)
 		label: 'Carousel';

--- a/src/Mirage-Carousel/MICarouselSettings.class.st
+++ b/src/Mirage-Carousel/MICarouselSettings.class.st
@@ -7,12 +7,13 @@ Class {
 	#classInstVars : [
 		'thumbnailUpdateTime'
 	],
-	#category : 'Mirage-Carousel-Settings'
+	#category : #'Mirage-Carousel-Settings'
 }
 
 { #category : #accessing }
 MICarouselSettings class >> defaultThumbnailUpdateTime [
-	^ 5 seconds
+
+	^ 5
 ]
 
 { #category : #accessing }
@@ -27,13 +28,10 @@ MICarouselSettings class >> thumbnailUpdateTime [
 
 { #category : #accessing }
 MICarouselSettings class >> thumbnailUpdateTime: anObject [
+
 	anObject isInteger
-		ifTrue: [ thumbnailUpdateTime := anObject seconds ].
-	
-	anObject class = Duration
-		ifFalse: [ self error: 'Thumbnail update time should be a duration or an integer.' ].
-		
-	thumbnailUpdateTime := anObject
+		ifTrue: [ thumbnailUpdateTime := anObject ]
+		ifFalse: [ self error: 'Thumbnail update time should be an integer.' ]
 ]
 
 { #category : #'settings-definition' }

--- a/src/Mirage-Carousel/MITitleMorph.class.st
+++ b/src/Mirage-Carousel/MITitleMorph.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'title'
 	],
-	#category : 'Mirage-Carousel-Morphic'
+	#category : #'Mirage-Carousel-Morphic'
 }
 
 { #category : #'instance creation' }

--- a/src/Mirage-Carousel/SystemWindow.extension.st
+++ b/src/Mirage-Carousel/SystemWindow.extension.st
@@ -39,7 +39,7 @@ SystemWindow >> mirageThumbnailPropertySymbol [
 { #category : #'*Mirage-Carousel' }
 SystemWindow >> scheduleThumbnailUpdate [
 	([ 
-		MICarouselSettings thumbnailUpdateTime wait.
+		MICarouselSettings thumbnailUpdateTime seconds wait.
 		self mirageMutex 
 			critical: [ 
 				self isCollapsed ifFalse: [ self updateMirageThumbnail ] ].


### PR DESCRIPTION
* Fixed settings on Pharo 7 (Pharo-7.0.0+rc1.build.63.sha.0ac2b792c9ce59356b74dccb0d59983f564cb478)
* Also added Carousel as the default view to improve UX. I find it very awkward to enable Mirage and after pressing Ctrl+Tab just see a grey overlay.

Fixes #10 