### PR TITLE
Make it clearer - master is also for Pharo 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Metacello new
     load
 ~~~
 
-## Development version
+## Development version (Pharo 7.x)
 Simply evaluate the following code snippet:
 ~~~
 Metacello new


### PR DESCRIPTION
This caught me out, as the 6.1 release isn't loadable in Pharo 7